### PR TITLE
Updated collator instructions to turing-node v1.8.0 (#124)

### DIFF
--- a/_docs/gov-dev/verify-runtime-upgrade.md
+++ b/_docs/gov-dev/verify-runtime-upgrade.md
@@ -8,13 +8,13 @@ date: 2022-06-30
 
 ### Finding the Proposal
 
-To find the proposed runtime upgrade navigate to [Turing's Democracy page](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc.turing.oak.tech#/democracy).  If a runtime upgrade has been proposed you will see a proposal under the `proposals` section for `parachainSystem.authorizeUpgrade` as shown in the image below.  For this example we are using a proposed runtime upgrade to v1.4.0.1.
+To find the proposed runtime upgrade navigate to [Turing's Democracy page](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc.turing.oak.tech#/democracy).  If a runtime upgrade has been proposed you will see a proposal under the `proposals` section for `parachainSystem.authorizeUpgrade` as shown in the image below.  For this example we are using a proposed runtime upgrade to v1.8.0.
 
 ![democracy-page](../../../assets/img/governance/democracy-page.png)
 
 ### Upgrade Preimage Information
 
-Once you have identified the proposal click on the arrow next to `parachainSystem.authorizeUpgrade` and expand for more details.  There you will see the H256 code hash for the corresponding release version v1.4.0.1.
+Once you have identified the proposal click on the arrow next to `parachainSystem.authorizeUpgrade` and expand for more details.  There you will see the H256 code hash for the corresponding release version v1.8.0.
 
 `0xfd8d2ee0b16c13a242e41e64b08d3b5e8470d2dd2e9228e1d8affcf3fc0628c2`
 
@@ -22,7 +22,7 @@ Once you have identified the proposal click on the arrow next to `parachainSyste
 
 ### Verify Code
 
-The necessary information to verify the code can be found in the corresponding release page on Github.  The release page for v1.4.0.1 can be found [here](https://github.com/OAK-Foundation/OAK-blockchain/releases/tag/v1.4.0.1).  To view previous releases you can navigate [here](https://github.com/OAK-Foundation/OAK-blockchain/releases).
+The necessary information to verify the code can be found in the corresponding release page on Github.  The release page for v1.8.0 can be found [here](https://github.com/OAK-Foundation/OAK-blockchain/releases/tag/v1.8.0).  To view previous releases you can navigate [here](https://github.com/OAK-Foundation/OAK-blockchain/releases).
 
 First, you will want to verify the `BLAKE2_256` hash in the release notes matches the proposal `codeHash` from the previous section.  Next, you can build your own WASM runtime to compare with the proposed upgrade.
 
@@ -34,7 +34,11 @@ First, you will want to verify the `BLAKE2_256` hash in the release notes matche
 2. Follow the directions in OAK-blockchain repository to [build from source](https://github.com/OAK-Foundation/OAK-blockchain#building-from-source).
 3. Checkout release branch.
 ```
-git checkout v1.4.0.1
+git clone git@github.com:OAK-Foundation/OAK-blockchain.git
+git fetch --all --tags
+git checkout tags/v1.8.0 -b branch-1.8.0
+
+Switched to a new branch 'branch-1.8.0'
 ```
 4. Build release with srtool.
 ```

--- a/_docs/setup-collator-node.md
+++ b/_docs/setup-collator-node.md
@@ -60,11 +60,14 @@ curl -L https://github.com/OAK-Foundation/OAK-blockchain/releases/download/$vers
 ```
 
 #### Option 2: Compile the binary
-If you are using another machine, or are struggling with errors from the above, you may need to compile the binary within your node. If you're running a different OS, please compile the binary first and follow the instructions in the OAK-blockchain [README](https://github.com/OAK-Foundation/OAK-blockchain#install-oak-blockchain). For example, for the v1.4.0 binary, you can run the following command on your node.
+If you are using another machine, or are struggling with errors from the above, you may need to compile the binary within your node. If you're running a different OS, please compile the binary first and follow the instructions in the OAK-blockchain [README](https://github.com/OAK-Foundation/OAK-blockchain#install-oak-blockchain). For example, for the v1.8.0 binary, you can run the following command on your node.
 
 ```
-git clone git@github.com:OAK-Foundation/OAK-blockchain.git    
-git checkout v1.4.0
+git clone git@github.com:OAK-Foundation/OAK-blockchain.git
+git fetch --all --tags
+git checkout tags/v1.8.0 -b branch-1.8.0
+
+Switched to a new branch 'branch-1.8.0'
 ```
 
 Then build your executable.
@@ -79,7 +82,7 @@ cargo build --release --features turing-node
 If you choose to run the collator via Docker, you can find the Docker repository linked in the helpful resources above. You can grab the latest image (tagged `latest`), or the specific version. Create a volume for your data and check that the volume exists by inspecting. The following commands help you to do so.
 
 ```
-docker pull oaknetwork/turing:1.4.0
+docker pull oaknetwork/turing:latest
 docker volume create turing-data
 docker volume inspect turing-data
 ```
@@ -108,7 +111,7 @@ oak-collator \
 #### Option 3: Docker users
 If you're using a Linux box, you can simply run the following for Turing:
 ```
-docker run -d -p 30333:30333 -p 9944:9944 -p 9933:9933  -v turing-data:/data oaknetwork/turing:1.4.0 \
+docker run -d -p 30333:30333 -p 9944:9944 -p 9933:9933  -v turing-data:/data oaknetwork/turing:latest \
   --name=YOUR_COLLATOR_NAME \
   --base-path=/data \
   --chain=turing \

--- a/_docs/upgrade-collator-node.md
+++ b/_docs/upgrade-collator-node.md
@@ -13,28 +13,40 @@ The steps below should only cause 3-5 minutes of downtime for your node, if done
 ## How to upgrade your node
 
 ### Step 1: Get to your node
-SSH to your target node, and make sure it's functioning properly by vetting Telemetry, and your monitoring/dashboards.
+SSH to your target node, and make sure it's functioning properly by vetting [Polkadot Telemetry](https://telemetry.polkadot.io/#list/0x0f62b701fb12d02237a33b84818c11f621653d2b1614c777973babf4652b535d), and your monitoring/dashboards.
 
 ### Step 2: Get the new binary ready
 
-#### Option 1: Grab a compiled binary from OAK's Github
-If you are using Ubuntu (20.04+ LTS x64), you can run the binary compiled by OAK that can be found [here](https://github.com/OAK-Foundation/OAK-blockchain/releases/latest). You'll use this to run your collator on your node. To acquire a copy of this via command line, use the commands below.
+#### Option 1: Download a compiled binary from OAK's Github
+If you are using Ubuntu (20.04+ LTS x64), you can run the binary compiled by OAK that can be found [here](https://github.com/OAK-Foundation/OAK-blockchain/releases/latest). Below commands will help you download the binary via command line.
 
+First, get the latest version number and store it in $version variable.
 ```
 latest_url=$(curl -Lsf -w %{url_effective} https://github.com/OAK-Foundation/OAK-blockchain/releases/latest/download/)
 version=${latest_url##*/}
-curl -L https://github.com/OAK-Foundation/OAK-blockchain/releases/download/$version/oak-collator -o oak-collator
+echo $version
+```
+
+Then, compose the binary’s URL and download it a local `./tmp` folder. In addition, run chmod 700 command to make sure the downloaded file is executable by the current linux user.
+```
+mkdir tmp
+curl -L https://github.com/OAK-Foundation/OAK-blockchain/releases/download/$version/oak-collator -o ./tmp/oak-collator
+
+chmod 700 ./tmp/oak-collator
 ```
 
 #### Option 2: Compile the binary
-If you are using another machine, or are struggling with errors from the above, you may need to compile the binary within your node. If you're running a different OS, please compile the binary first and follow the instructions in the OAK-blockchain [README](https://github.com/OAK-Foundation/OAK-blockchain#install-oak-blockchain). For example, for the v1.4.0 binary, you can run the following command on your node.
+If you are using another machine, or are struggling with errors from the above, you may need to compile the binary within your node. If you're running a different OS, please compile the binary first and follow the instructions in the OAK-blockchain [README](https://github.com/OAK-Foundation/OAK-blockchain#install-oak-blockchain). For example, for the v1.8.0 binary, you can run the following command on your node.
 
 ```
-git clone git@github.com:OAK-Foundation/OAK-blockchain.git    
-git checkout v1.4.0
+git clone git@github.com:OAK-Foundation/OAK-blockchain.git
+git fetch --all --tags
+git checkout tags/v1.8.0 -b branch-1.8.0
+
+Switched to a new branch 'branch-1.8.0'
 ```
 
-Then build your executable.
+Then build your executable for Turing Network.
 
 ```
 cargo build --release --features turing-node
@@ -46,7 +58,7 @@ cargo build --release --features turing-node
 If you choose to run the collator via Docker, you can find the Docker repository linked in the helpful resources above. You can grab the latest image (tagged `latest`), or the specific version. Create a volume for your data and check that the volume exists by inspecting. The following commands help you to do so.
 
 ```
-docker pull oaknetwork/turing:1.4.0
+docker pull oaknetwork/turing:latest
 docker volume create turing-data
 docker volume inspect turing-data
 ```
@@ -56,15 +68,16 @@ docker volume inspect turing-data
 #### Options 1 & 2
 
 Linux binaries can be safely replaced while running if you perform an `unlink()` before placing the new file:
-1. Remove the existing binary (ie. `rm oak-collator`)
-2. Move the new binary into position (ie. `mv /tmp/oak-collator /data/dir/oak-collator`)
+1. Navigate to the root of the project, or parent of the `oak-collator` folder.
+2. Remove the existing binary with `rm oak-collator`
+3. Move the new binary into position (ie. `mv ./tmp/oak-collator oak-collator`)
 
 If you are not comfortable replacing the running binary, you can stop the service (ie. `systemctl stop oak-collator`) and follow the same steps.
 
 #### Option 3
 
 ```bash
-docker pull oaknetwork/turing:1.4.0
+docker pull oaknetwork/turing:latest
 ```
 
 ### Step 4: Restart your service
@@ -81,7 +94,7 @@ sudo systemctl restart oak-collator
 ```bash
 docker stop EXISTING_CONTAINER_ID
 docker run -d -p 30333:30333 -p 9944:9944 -p 9933:9933  -v turing-data:/data
-oaknetwork/turing:1.4.0 \
+oaknetwork/turing:latest \
   --name=YOUR_COLLATOR_NAME \
   --base-path=/data \
   --chain=turing \


### PR DESCRIPTION
* Updated collator instructions to v1.8.0

* Fixed a typo in _docs/upgrade-collator-node.md